### PR TITLE
Report vm & system metrics to datadog.

### DIFF
--- a/lib/exometer_datadog.ex
+++ b/lib/exometer_datadog.ex
@@ -102,7 +102,6 @@ defmodule ExometerDatadog do
     end
 
     load_stats = ~w(1 5 15)a
-
     new_metric(
       [:system, :load],
       {:function, SystemMetrics, :loadavg, [], :proplist, load_stats},
@@ -111,11 +110,18 @@ defmodule ExometerDatadog do
     )
 
     memory_stats = ~w(total free buffered cached)a
-
     new_metric(
       [:system, :mem],
       {:function, SystemMetrics, :meminfo, [], :proplist, memory_stats},
       memory_stats,
+      5000
+    )
+
+    swap_stats = ~w(free total used)a
+    new_metric(
+      [:system, :swap],
+      {:function, SystemMetrics, :swapinfo, [], :proplist, swap_stats},
+      swap_stats,
       5000
     )
   end
@@ -124,7 +130,7 @@ defmodule ExometerDatadog do
   Removes the system metrics added by `add_system_metrics/0`
   """
   def remove_system_metrics do
-    [[:system, :load], [:system, :mem]]
+    [[:system, :load], [:system, :mem], [:system, :swap]]
     |> Enum.each(&delete_metric/1)
   end
 

--- a/lib/exometer_datadog.ex
+++ b/lib/exometer_datadog.ex
@@ -109,7 +109,7 @@ defmodule ExometerDatadog do
       5000
     )
 
-    memory_stats = ~w(total free buffered cached)a
+    memory_stats = SystemMetrics.meminfo |> Keyword.keys
     new_metric(
       [:system, :mem],
       {:function, SystemMetrics, :meminfo, [], :proplist, memory_stats},
@@ -117,7 +117,7 @@ defmodule ExometerDatadog do
       5000
     )
 
-    swap_stats = ~w(free total used)a
+    swap_stats = SystemMetrics.swapinfo |> Keyword.keys
     new_metric(
       [:system, :swap],
       {:function, SystemMetrics, :swapinfo, [], :proplist, swap_stats},

--- a/lib/exometer_datadog.ex
+++ b/lib/exometer_datadog.ex
@@ -13,9 +13,9 @@ defmodule ExometerDatadog do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    if Application.get_env(:exometer_datadog, :add_reporter) do
-      register_reporter
-    end
+    if get_env(:add_reporter), do: register_reporter
+    if get_env(:report_system_metrics), do: add_system_metrics
+    if get_env(:report_vm_metrics), do: add_vm_metrics
 
     children = []
 

--- a/lib/exometer_datadog/system_metrics.ex
+++ b/lib/exometer_datadog/system_metrics.ex
@@ -1,0 +1,24 @@
+defmodule ExometerDatadog.SystemMetrics do
+  # Gets the load average.
+  def loadavg do
+    res =
+      with {:ok, data} <- read_file("/proc/loadavg"),
+           [one, five, fifteen | _] <- String.split(data, " "),
+           {one, ""} <- Float.parse(one),
+           {five, ""} <- Float.parse(five),
+           {fifteen, ""} <- Float.parse(fifteen),
+           do: ["1": one, "5": five, "15": fifteen]
+
+    if Keyword.keyword?(res), do: res, else: []
+  end
+
+  # We can't use File.read because it doesn't work with /proc files. (Mostly
+  # becaues it calls stat on them, sees they have 0 size and returns that
+  # accordingly)
+  defp read_file(filename) do
+    with {:ok, file} <- File.open(filename),
+         data = IO.binread(file, :all),
+         :ok <- File.close(file),
+         do: {:ok, data}
+  end
+end

--- a/lib/exometer_datadog/system_metrics.ex
+++ b/lib/exometer_datadog/system_metrics.ex
@@ -53,7 +53,7 @@ defmodule ExometerDatadog.SystemMetrics do
       {:ok, data} ->
         stats = data |> String.split(~r/\s+/) |> Stream.chunk(3, 3, [])
         for [stat, count, unit] <- stats, Map.has_key?(mem_stats, stat) do
-          {mem_stats[stat], convert_to_bytes(count, unit)}
+          {mem_stats[stat], convert_to_megabytes(count, unit)}
         end
       _ ->
         []
@@ -61,12 +61,12 @@ defmodule ExometerDatadog.SystemMetrics do
   end
 
   # Converts a count into some
-  defp convert_to_bytes(count, unit) when is_binary(count) do
+  defp convert_to_megabytes(count, unit) when is_binary(count) do
     {count, ""} = Integer.parse(count)
-    convert_to_bytes(count, unit)
+    convert_to_megabytes(count, unit)
   end
-  defp convert_to_bytes(count, "B"), do: count
-  defp convert_to_bytes(count, "kB"), do: count * 1024
-  defp convert_to_bytes(count, "mB"), do: count * 1024 * 1024
-  defp convert_to_bytes(count, "gB"), do: count * 1024 * 1024 * 1024
+  defp convert_to_megabytes(count, "B"), do: count / 1024 / 1024
+  defp convert_to_megabytes(count, "kB"), do: count / 1024
+  defp convert_to_megabytes(count, "mB"), do: count
+  defp convert_to_megabytes(count, "gB"), do: count * 1024
 end

--- a/lib/exometer_datadog/system_metrics.ex
+++ b/lib/exometer_datadog/system_metrics.ex
@@ -17,12 +17,19 @@ defmodule ExometerDatadog.SystemMetrics do
   end
 
   def meminfo do
-    read_meminfo %{
+    rv = read_meminfo %{
       "MemTotal:" => :total,
       "MemFree:" => :free,
       "Buffers:" => :buffered,
       "Cached:" => :cached,
+      "Shmem:" => :shared,
+      "MemAvailable:" => :usable
     }
+    if rv[:free] && rv[:total] do
+      [{:used, rv[:total] - rv[:free]} | rv]
+    else
+      rv
+    end
   end
 
   def swapinfo do

--- a/lib/exometer_datadog/system_metrics.ex
+++ b/lib/exometer_datadog/system_metrics.ex
@@ -25,6 +25,18 @@ defmodule ExometerDatadog.SystemMetrics do
     }
   end
 
+  def swapinfo do
+    rv = read_meminfo %{
+      "SwapFree:" => :free,
+      "SwapTotal:" => :total
+    }
+    if rv[:free] && rv[:total] do
+      [{:used, rv[:total] - rv[:free]} | rv]
+    else
+      rv
+    end
+  end
+
   # We can't use File.read because it doesn't work with /proc files. (Mostly
   # becaues it calls stat on them, sees they have 0 size and returns that
   # accordingly)

--- a/lib/exometer_datadog/system_metrics.ex
+++ b/lib/exometer_datadog/system_metrics.ex
@@ -1,5 +1,9 @@
 defmodule ExometerDatadog.SystemMetrics do
-  # Gets the load average.
+  @moduledoc """
+  Gets the load averages of the system.
+
+  Only works on linux with access to /proc/loadavg.
+  """
   def loadavg do
     res =
       with {:ok, data} <- read_file("/proc/loadavg"),
@@ -12,6 +16,15 @@ defmodule ExometerDatadog.SystemMetrics do
     if Keyword.keyword?(res), do: res, else: []
   end
 
+  def meminfo do
+    read_meminfo %{
+      "MemTotal:" => :total,
+      "MemFree:" => :free,
+      "Buffers:" => :buffered,
+      "Cached:" => :cached,
+    }
+  end
+
   # We can't use File.read because it doesn't work with /proc files. (Mostly
   # becaues it calls stat on them, sees they have 0 size and returns that
   # accordingly)
@@ -21,4 +34,27 @@ defmodule ExometerDatadog.SystemMetrics do
          :ok <- File.close(file),
          do: {:ok, data}
   end
+
+  # Reads data from /proc/meminfo.  Extracts stats specified in mem_stats
+  defp read_meminfo(mem_stats) do
+    case read_file("/proc/meminfo") do
+      {:ok, data} ->
+        stats = data |> String.split(~r/\s+/) |> Stream.chunk(3, 3, [])
+        for [stat, count, unit] <- stats, Map.has_key?(mem_stats, stat) do
+          {mem_stats[stat], convert_to_bytes(count, unit)}
+        end
+      _ ->
+        []
+    end
+  end
+
+  # Converts a count into some
+  defp convert_to_bytes(count, unit) when is_binary(count) do
+    {count, ""} = Integer.parse(count)
+    convert_to_bytes(count, unit)
+  end
+  defp convert_to_bytes(count, "B"), do: count
+  defp convert_to_bytes(count, "kB"), do: count * 1024
+  defp convert_to_bytes(count, "mB"), do: count * 1024 * 1024
+  defp convert_to_bytes(count, "gB"), do: count * 1024 * 1024 * 1024
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,8 @@ defmodule ExometerDatadog.Mixfile do
 
   defp default_config(_env) do
     [add_reporter: true,
-     reporter_config: []]
+     reporter_config: [],
+     update_frequency: 1000,
+     metric_prefix: nil]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,8 @@ defmodule ExometerDatadog.Mixfile do
     [add_reporter: true,
      reporter_config: [],
      update_frequency: 1000,
-     metric_prefix: nil]
+     metric_prefix: nil,
+     report_system_metrics: false,
+     report_vm_metrics: false]
   end
 end

--- a/test/fixtures.exs
+++ b/test/fixtures.exs
@@ -1,11 +1,3 @@
 defmodule ExometerDatadogFixtures do
   use ExUnitFixtures.FixtureModule
-
-  deffixture http_client, scope: :module do
-    TestHttpClient.start()
-
-    on_exit fn -> TestHttpClient.stop() end
-
-    TestHttpClient
-  end
 end

--- a/test/reporter_test.exs
+++ b/test/reporter_test.exs
@@ -4,7 +4,7 @@ defmodule ReporterTest do
   alias ExometerDatadog.Reporter
   doctest Reporter
 
-  deffixture http_client(http_client) do
+  deffixture http_client do
     send Reporter, :clear
     TestHttpClient.reset
   end

--- a/test/system_metrics_test.exs
+++ b/test/system_metrics_test.exs
@@ -1,0 +1,47 @@
+defmodule SystemMetricsTest do
+  use ExUnitFixtures
+  use ExUnit.Case
+
+  alias ExometerDatadog.{Reporter, SystemMetrics}
+
+  deffixture system_metrics, autouse: true do
+    ExometerDatadog.add_system_metrics
+
+    on_exit fn -> ExometerDatadog.remove_system_metrics end
+  end
+
+  @expected_metrics [[:system, :load]]
+
+  test "can get values of system metrics" do
+    for metric <- @expected_metrics do
+      {:ok, _} = :exometer.get_value(metric)
+    end
+  end
+
+  test "registers subscribers" do
+    # We won't be subscribed if we don't have a `proc` folder to get results from.
+    if File.exists?("/proc") do
+      subs = :exometer_report.list_subscriptions(Reporter)
+      metric_names = for {name, _, _, _} <- subs, into: MapSet.new, do: name
+      assert metric_names == MapSet.new(@expected_metrics)
+    end
+  end
+
+  test "remove_system_metrics removes metrics & subscriptions" do
+    ExometerDatadog.remove_system_metrics
+    for metric <- @expected_metrics do
+      {:error, :not_found} = :exometer.get_value(metric)
+    end
+    [] = :exometer_report.list_subscriptions(Reporter)
+  end
+
+  test "calling loadavg directly" do
+    if File.exists?("/proc/loadavg") do
+      keys = SystemMetrics.loadavg |> Keyword.keys
+      assert keys == ~w(1 5 15)a
+    else
+      assert SystemMetrics.loadavg == []
+    end
+  end
+
+end

--- a/test/system_metrics_test.exs
+++ b/test/system_metrics_test.exs
@@ -47,7 +47,7 @@ defmodule SystemMetricsTest do
   test "calling meminfo directly" do
     if File.exists?("/proc/meminfo") do
       keys = SystemMetrics.meminfo |> Keyword.keys
-      assert keys == ~w(total free buffered cached)a
+      assert keys == ~w(used total free buffered cached shared)a
     else
       assert SystemMetrics.meminfo == []
     end

--- a/test/system_metrics_test.exs
+++ b/test/system_metrics_test.exs
@@ -10,7 +10,7 @@ defmodule SystemMetricsTest do
     on_exit fn -> ExometerDatadog.remove_system_metrics end
   end
 
-  @expected_metrics [[:system, :load]]
+  @expected_metrics [[:system, :load], [:system, :mem]]
 
   test "can get values of system metrics" do
     for metric <- @expected_metrics do
@@ -41,6 +41,15 @@ defmodule SystemMetricsTest do
       assert keys == ~w(1 5 15)a
     else
       assert SystemMetrics.loadavg == []
+    end
+  end
+
+  test "calling meminfo directly" do
+    if File.exists?("/proc/meminfo") do
+      keys = SystemMetrics.meminfo |> Keyword.keys
+      assert keys == ~w(total free buffered cached)a
+    else
+      assert SystemMetrics.meminfo == []
     end
   end
 

--- a/test/system_metrics_test.exs
+++ b/test/system_metrics_test.exs
@@ -10,7 +10,7 @@ defmodule SystemMetricsTest do
     on_exit fn -> ExometerDatadog.remove_system_metrics end
   end
 
-  @expected_metrics [[:system, :load], [:system, :mem]]
+  @expected_metrics [[:system, :load], [:system, :mem], [:system, :swap]]
 
   test "can get values of system metrics" do
     for metric <- @expected_metrics do
@@ -48,6 +48,15 @@ defmodule SystemMetricsTest do
     if File.exists?("/proc/meminfo") do
       keys = SystemMetrics.meminfo |> Keyword.keys
       assert keys == ~w(total free buffered cached)a
+    else
+      assert SystemMetrics.meminfo == []
+    end
+  end
+
+  test "calling swapinfo directly" do
+    if File.exists?("/proc/meminfo") do
+      keys = SystemMetrics.swapinfo |> Keyword.keys
+      assert keys == ~w(used total free)a
     else
       assert SystemMetrics.meminfo == []
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,3 +34,4 @@ defmodule TestHttpClient do
   end
 end
 
+TestHttpClient.start

--- a/test/vm_metrics_test.exs
+++ b/test/vm_metrics_test.exs
@@ -10,22 +10,27 @@ defmodule VmMetricsTest do
     on_exit fn -> ExometerDatadog.remove_vm_metrics end
   end
 
+  @expected_metrics [[:erlang, :memory],
+                     [:erlang, :statistics],
+                     [:erlang, :system_info]]
+
   test "can get values of vm metrics" do
-    {:ok, _} = :exometer.get_value([:erlang, :memory])
-    {:ok, _} = :exometer.get_value([:erlang, :statistics])
+    for metric <- @expected_metrics do
+      {:ok, _} = :exometer.get_value(metric)
+    end
   end
 
   test "registers subscribers" do
     subs = :exometer_report.list_subscriptions(Reporter)
     metric_names = for {name, _, _, _} <- subs, into: MapSet.new, do: name
-    assert metric_names == MapSet.new([[:erlang, :memory],
-                                       [:erlang, :statistics]])
+    assert metric_names == MapSet.new(@expected_metrics)
   end
 
   test "remove_vm_metrics removes metrics & subscriptions" do
     ExometerDatadog.remove_vm_metrics
-    {:error, :not_found} = :exometer.get_value([:erlang, :memory])
-    {:error, :not_found} = :exometer.get_value([:erlang, :statistics])
+    for metric <- @expected_metrics do
+      {:error, :not_found} = :exometer.get_value(metric)
+    end
     [] = :exometer_report.list_subscriptions(Reporter)
   end
 end

--- a/test/vm_metrics_test.exs
+++ b/test/vm_metrics_test.exs
@@ -1,0 +1,31 @@
+defmodule VmMetricsTest do
+  use ExUnitFixtures
+  use ExUnit.Case
+
+  alias ExometerDatadog.Reporter
+
+  deffixture vm_metrics, autouse: true do
+    ExometerDatadog.add_vm_metrics
+
+    on_exit fn -> ExometerDatadog.remove_vm_metrics end
+  end
+
+  test "can get values of vm metrics" do
+    {:ok, _} = :exometer.get_value([:erlang, :memory])
+    {:ok, _} = :exometer.get_value([:erlang, :statistics])
+  end
+
+  test "registers subscribers" do
+    subs = :exometer_report.list_subscriptions(Reporter)
+    metric_names = for {name, _, _, _} <- subs, into: MapSet.new, do: name
+    assert metric_names == MapSet.new([[:erlang, :memory],
+                                       [:erlang, :statistics]])
+  end
+
+  test "remove_vm_metrics removes metrics & subscriptions" do
+    ExometerDatadog.remove_vm_metrics
+    {:error, :not_found} = :exometer.get_value([:erlang, :memory])
+    {:error, :not_found} = :exometer.get_value([:erlang, :statistics])
+    [] = :exometer_report.list_subscriptions(Reporter)
+  end
+end


### PR DESCRIPTION
This adds support for reporting vm & system metrics to datadog when appropriate functions are called.
