### PR TITLE
Host can now be configured via a function.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,11 +6,5 @@ use Mix.Config
 config :lager, error_logger_redirect: false
 
 if Mix.env == :test do
-  config :exometer_datadog, [
-    api_key: "ab",
-    app_key: "cd",
-    reporter_config: [flush_period: 20,
-                      host: "testhost",
-                      http_client: TestHttpClient]
-  ]
+  config :exometer_datadog, add_reporter: :false
 end

--- a/lib/exometer_datadog.ex
+++ b/lib/exometer_datadog.ex
@@ -31,7 +31,10 @@ defmodule ExometerDatadog do
 
   - `api_key` is the datadog API key to send metrics with.
   - `app_key` is the datadog app key to send metrics with.
-  - `host` is the hostname to report to datadog.
+  - `host_fn` is a `{module, function}` tuple that specifies a function to be
+    called to determine the hostname to report to datadog. Defaults to
+    `:inet.gethostname`
+  - `host` can be used instead of `host_fn` to hard-code the hostname.
   - `add_reporter` controls whether ExometerDatadog.Reporter will be registered
     on application startup. By default this is true.
   - `report_vm_metrics` controls whether VM metrics will be reported to datadog.
@@ -112,7 +115,7 @@ defmodule ExometerDatadog do
                        app_key: get_env(:app_key))
       |> Keyword.merge(opts)
 
-    :exometer_report.add_reporter(Reporter, reporter_config)
+    :ok = :exometer_report.add_reporter(Reporter, reporter_config)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -47,6 +47,7 @@ defmodule ExometerDatadog.Mixfile do
      update_frequency: 1000,
      metric_prefix: nil,
      report_system_metrics: false,
-     report_vm_metrics: false]
+     report_vm_metrics: false,
+     host_fn: {:inet, :gethostname}]
   end
 end

--- a/test/fixtures.exs
+++ b/test/fixtures.exs
@@ -1,3 +1,19 @@
 defmodule ExometerDatadogFixtures do
   use ExUnitFixtures.FixtureModule
+
+  alias ExometerDatadog.Reporter
+
+  deffixture reporter(context) do
+    [flush_period: 20, host: "testhost", http_client: TestHttpClient,
+     api_key: "ab", app_key: "cd"]
+    |> Keyword.merge(context[:reporter_opts] || [])
+    |> ExometerDatadog.register_reporter()
+
+    # Give the reporter time to startup.
+    :timer.sleep(50)
+
+    on_exit fn ->
+      :ok = :exometer_report.remove_reporter(Reporter)
+    end
+  end
 end

--- a/test/reporter_test.exs
+++ b/test/reporter_test.exs
@@ -1,15 +1,14 @@
 defmodule ReporterTest do
   use ExUnitFixtures
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias ExometerDatadog.Reporter
   doctest Reporter
 
   deffixture http_client do
-    send Reporter, :clear
     TestHttpClient.reset
   end
 
-  deffixture metric(http_client) do
+  deffixture metric(http_client, reporter) do
     :exometer.new([:test], :gauge)
     :exometer.update([:test], 10)
     :exometer_report.subscribe(Reporter, [:test], [:value], 5)
@@ -22,7 +21,7 @@ defmodule ReporterTest do
 
   @tag fixtures: [:metric]
   test "metrics are flushed every period" do
-    :timer.sleep(45)
+    :timer.sleep(35)
     requests = TestHttpClient.requests
     assert length(requests) in 1..2
     initial_requests = length(requests)
@@ -32,7 +31,7 @@ defmodule ReporterTest do
 
   @tag fixtures: [:metric]
   test "metric payload is correct" do
-    :timer.sleep(45)
+    :timer.sleep(35)
     [{url, body, headers, _opts} | _] = TestHttpClient.requests
     assert url == "https://app.datadoghq.com/api/v1/series?api_key=ab&application_key=cd"
     assert headers == [{"Content-Type", "application/json"}]
@@ -51,6 +50,34 @@ defmodule ReporterTest do
       [[_, x]] ->
         assert x == 10
     end
+  end
+
+  @tag fixtures: [:metric]
+  @tag reporter_opts: [host: nil]
+  test "uses hostname by default" do
+    :timer.sleep(35)
+    [{url, body, headers, _opts} | _] = TestHttpClient.requests
+
+    {:ok, expected_host} = :inet.gethostname()
+
+    data = Poison.decode!(body)
+    [metric] = data["series"]
+    assert metric["host"] == expected_host
+  end
+
+  @tag fixtures: [:metric]
+  @tag reporter_opts: [host: nil, host_fn: {__MODULE__, :test_host_fn}]
+  test "can use a user defined host_fn" do
+    :timer.sleep(35)
+    [{url, body, headers, _opts} | _] = TestHttpClient.requests
+
+    data = Poison.decode!(body)
+    [metric] = data["series"]
+    assert metric["host"] == "some_test_host"
+  end
+
+  def test_host_fn do
+    {:ok, "some_test_host"}
   end
 
   test "error if api_key not set" do

--- a/test/system_metrics_test.exs
+++ b/test/system_metrics_test.exs
@@ -1,10 +1,10 @@
 defmodule SystemMetricsTest do
   use ExUnitFixtures
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias ExometerDatadog.{Reporter, SystemMetrics}
 
-  deffixture system_metrics, autouse: true do
+  deffixture system_metrics(reporter), autouse: true do
     ExometerDatadog.add_system_metrics
 
     on_exit fn -> ExometerDatadog.remove_system_metrics end

--- a/test/vm_metrics_test.exs
+++ b/test/vm_metrics_test.exs
@@ -1,10 +1,10 @@
 defmodule VmMetricsTest do
   use ExUnitFixtures
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias ExometerDatadog.Reporter
 
-  deffixture vm_metrics, autouse: true do
+  deffixture vm_metrics(reporter), autouse: true do
     ExometerDatadog.add_vm_metrics
 
     on_exit fn -> ExometerDatadog.remove_vm_metrics end


### PR DESCRIPTION
This allows the host to be retrieved automatically from the hostname, or
potentially from some other source (AWS instance info, for example).

Fixes #3.
